### PR TITLE
Hotfix/default services

### DIFF
--- a/src/Nancy.OAuth2.Tests/Nancy.OAuth2.Tests.csproj
+++ b/src/Nancy.OAuth2.Tests/Nancy.OAuth2.Tests.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Modules\AuthorizeModuleTests.cs" />
     <Compile Include="Modules\TokenModuleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\DefaultAuthorizationEndpointServiceTests.cs" />
+    <Compile Include="Services\DefaultTokenEndpointServiceTests.cs" />
     <Compile Include="StubFactory.cs" />
     <Compile Include="TestRootPathProvider.cs" />
   </ItemGroup>

--- a/src/Nancy.OAuth2.Tests/Services/DefaultAuthorizationEndpointServiceTests.cs
+++ b/src/Nancy.OAuth2.Tests/Services/DefaultAuthorizationEndpointServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Nancy.OAuth2.Models;
+using Nancy.OAuth2.Services;
+using NUnit.Framework;
+
+namespace Nancy.OAuth2.Tests.Services
+{
+    [TestFixture]
+    [Parallelizable]
+    public class DefaultAuthorizationEndpointServiceTests
+    {
+        private IAuthorizationEndpointService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _service = new DefaultAuthorizationEndpointService();
+        }
+
+        [Test]
+        public void GenerateAuthorizationToken_ShouldThrow_NotImplementedException()
+        {
+            var request = new AuthorizationRequest();
+            var context = new NancyContext();
+
+            Assert.Throws<NotImplementedException>(() => _service.GenerateAuthorizationToken(request, context));
+        }
+
+        [Test]
+        public void ValidateRequest_ShouldThrow_NotImplementedException()
+        {
+            var request = new AuthorizationRequest();
+            var context = new NancyContext();
+
+            Assert.Throws<NotImplementedException>(() => _service.ValidateRequest(request, context));
+        }
+
+        [Test]
+        public void GetAuthorizationView_ShouldThrow_NotImplementedException()
+        {
+            var request = new AuthorizationRequest();
+            var context = new NancyContext();
+
+            Assert.Throws<NotImplementedException>(() => _service.GetAuthorizationView(request, context));
+        }
+    }
+}

--- a/src/Nancy.OAuth2.Tests/Services/DefaultTokenEndpointServiceTests.cs
+++ b/src/Nancy.OAuth2.Tests/Services/DefaultTokenEndpointServiceTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Nancy.OAuth2.Models;
+using Nancy.OAuth2.Services;
+using NUnit.Framework;
+
+namespace Nancy.OAuth2.Tests.Services
+{
+    [TestFixture]
+    [Parallelizable]
+    public class DefaultTokenEndpointServiceTests
+    {
+        private ITokenEndpointService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _service = new DefaultTokenEndpointService();
+        }
+
+        [Test]
+        public void ValidateRequest_ShouldThrow_NotImplementedException()
+        {
+            var request = new TokenRequest();
+            var context = new NancyContext();
+
+            Assert.Throws<NotImplementedException>(() => _service.ValidateRequest(request, context));
+        }
+
+        [Test]
+        public void CreateTokenResponse_ShouldThrow_NotImplementedException()
+        {
+            var request = new TokenRequest();
+            var context = new NancyContext();
+
+            Assert.Throws<NotImplementedException>(() => _service.CreateTokenResponse(request, context));
+        }
+    }
+}

--- a/src/Nancy.OAuth2/Nancy.OAuth2.csproj
+++ b/src/Nancy.OAuth2/Nancy.OAuth2.csproj
@@ -64,6 +64,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryStringExtensions.cs" />
     <Compile Include="ResponseFormatterExtensions.cs" />
+    <Compile Include="Services\DefaultAuthorizationEndpointService.cs" />
+    <Compile Include="Services\DefaultTokenEndpointService.cs" />
     <Compile Include="Services\IAuthorizationEndpointService.cs" />
     <Compile Include="Services\ITokenEndpointService.cs" />
   </ItemGroup>

--- a/src/Nancy.OAuth2/Services/DefaultAuthorizationEndpointService.cs
+++ b/src/Nancy.OAuth2/Services/DefaultAuthorizationEndpointService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Nancy.OAuth2.Models;
+
+namespace Nancy.OAuth2.Services
+{
+    public class DefaultAuthorizationEndpointService : IAuthorizationEndpointService
+    {
+        public string GenerateAuthorizationToken(AuthorizationRequest request, NancyContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public OAuthValidationResult ValidateRequest(AuthorizationRequest request, NancyContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Tuple<string, object> GetAuthorizationView(AuthorizationRequest request, NancyContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Nancy.OAuth2/Services/DefaultTokenEndpointService.cs
+++ b/src/Nancy.OAuth2/Services/DefaultTokenEndpointService.cs
@@ -1,0 +1,17 @@
+﻿using Nancy.OAuth2.Models;
+
+namespace Nancy.OAuth2.Services
+{
+    public class DefaultTokenEndpointService : ITokenEndpointService
+    {
+        public OAuthValidationResult ValidateRequest(TokenRequest request, NancyContext context)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public TokenResponse CreateTokenResponse(TokenRequest request, NancyContext context)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Created default services so your Nancy app doesn't crash if you don't provide implementations of the `IAuthorizationEndpointService` and `ITokenEndpointService`.
