### PR TITLE
Hotfix/pass client id and secret into token endpoint service

### DIFF
--- a/src/Nancy.OAuth2.Tests/Modules/TokenModuleTests.cs
+++ b/src/Nancy.OAuth2.Tests/Modules/TokenModuleTests.cs
@@ -1,4 +1,5 @@
-﻿using FakeItEasy;
+﻿using System.Linq;
+using FakeItEasy;
 using Nancy.OAuth2.Enums;
 using Nancy.OAuth2.Models;
 using Nancy.OAuth2.Modules;
@@ -118,7 +119,8 @@ namespace Nancy.OAuth2.Tests.Modules
                 with.FormValue("client_secret", "my-client-secret");
                 with.FormValue("code", "123");
                 with.FormValue("redirect_uri", "http://nancy-oauth.com/redirect");
-                with.FormValue("scope", "my-scope");
+                with.FormValue("scope", "my-scope-1");
+                with.FormValue("scope", "my-scope-2");
             });
 
             A.CallTo(() => _tokenEndpointService.ValidateRequest(A<TokenRequest>.That.Matches(x =>
@@ -129,7 +131,34 @@ namespace Nancy.OAuth2.Tests.Modules
                     x.ClientSecret == "my-client-secret" &&
                     x.Code == "123" &&
                     x.RedirectUri == "http://nancy-oauth.com/redirect" &&
-                    x.Scope == new[] {"my-scope"}), A<NancyContext>.Ignored))
+                    x.Scope.All(y => y == "my-scope-1" || y == "my-scope-2")), A<NancyContext>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Test]
+        public void Post_Should_Handle_No_Scopes_On_Form()
+        {
+            _browser.Post("/oauth/token", with =>
+            {
+                with.HttpRequest();
+                with.FormValue("grant_type", GrantTypes.Password);
+                with.FormValue("username", "myusername");
+                with.FormValue("password", "mypassword");
+                with.FormValue("client_id", "my-client-id");
+                with.FormValue("client_secret", "my-client-secret");
+                with.FormValue("code", "123");
+                with.FormValue("redirect_uri", "http://nancy-oauth.com/redirect");
+            });
+
+            A.CallTo(() => _tokenEndpointService.ValidateRequest(A<TokenRequest>.That.Matches(x =>
+                    x.GrantType == GrantTypes.Password &&
+                    x.Username == "myusername" &&
+                    x.Password == "mypassword" &&
+                    x.ClientId == "my-client-id" &&
+                    x.ClientSecret == "my-client-secret" &&
+                    x.Code == "123" &&
+                    x.RedirectUri == "http://nancy-oauth.com/redirect" &&
+                    !x.Scope.Any()), A<NancyContext>.Ignored))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
     }

--- a/src/Nancy.OAuth2.Tests/Modules/TokenModuleTests.cs
+++ b/src/Nancy.OAuth2.Tests/Modules/TokenModuleTests.cs
@@ -104,5 +104,33 @@ namespace Nancy.OAuth2.Tests.Modules
             Assert.AreEqual("test", body.Scope);
             Assert.AreEqual("bearer", body.TokenType);
         }
+
+        [Test]
+        public void Post_Should_Put_Form_Values_Into_TokenRequest()
+        {
+            _browser.Post("/oauth/token", with =>
+            {
+                with.HttpRequest();
+                with.FormValue("grant_type", GrantTypes.Password);
+                with.FormValue("username", "myusername");
+                with.FormValue("password", "mypassword");
+                with.FormValue("client_id", "my-client-id");
+                with.FormValue("client_secret", "my-client-secret");
+                with.FormValue("code", "123");
+                with.FormValue("redirect_uri", "http://nancy-oauth.com/redirect");
+                with.FormValue("scope", "my-scope");
+            });
+
+            A.CallTo(() => _tokenEndpointService.ValidateRequest(A<TokenRequest>.That.Matches(x =>
+                    x.GrantType == GrantTypes.Password &&
+                    x.Username == "myusername" &&
+                    x.Password == "mypassword" &&
+                    x.ClientId == "my-client-id" &&
+                    x.ClientSecret == "my-client-secret" &&
+                    x.Code == "123" &&
+                    x.RedirectUri == "http://nancy-oauth.com/redirect" &&
+                    x.Scope == new[] {"my-scope"}), A<NancyContext>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
     }
 }

--- a/src/Nancy.OAuth2.Tests/Nancy.OAuth2.Tests.csproj
+++ b/src/Nancy.OAuth2.Tests/Nancy.OAuth2.Tests.csproj
@@ -41,6 +41,10 @@
       <HintPath>..\packages\CsQuery.1.3.4\lib\net40\CsQuery.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FakeItEasy, Version=3.4.2.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.4.2\lib\net45\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Nancy, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nancy.1.4.3\lib\net40\Nancy.dll</HintPath>
       <Private>True</Private>

--- a/src/Nancy.OAuth2.Tests/packages.config
+++ b/src/Nancy.OAuth2.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsQuery" version="1.3.4" targetFramework="net45" />
+  <package id="FakeItEasy" version="3.4.2" targetFramework="net45" />
   <package id="Nancy" version="1.4.3" targetFramework="net45" />
   <package id="Nancy.Testing" version="1.4.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />

--- a/src/Nancy.OAuth2/ModelBinders/TokenRequestBinder.cs
+++ b/src/Nancy.OAuth2/ModelBinders/TokenRequestBinder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Nancy.ModelBinding;
 using Nancy.OAuth2.Models;
 
@@ -18,13 +19,18 @@ namespace Nancy.OAuth2.ModelBinders
                 ClientSecret = context.Request.Form["client_secret"],
                 Code = context.Request.Form["code"],
                 RedirectUri = context.Request.Form["redirect_uri"],
-                Scope = context.Request.Form["scope"]
+                Scope = ParseScope(context.Request.Form["scope"])
             };
         }
 
         public bool CanBind(Type modelType)
         {
             return modelType == typeof (TokenRequest);
+        }
+
+        private static IEnumerable<string> ParseScope(string value)
+        {
+            return (value ?? "").Split(new[] {","}, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/src/Nancy.OAuth2/ModelBinders/TokenRequestBinder.cs
+++ b/src/Nancy.OAuth2/ModelBinders/TokenRequestBinder.cs
@@ -14,6 +14,8 @@ namespace Nancy.OAuth2.ModelBinders
                 GrantType = context.Request.Form["grant_type"],
                 Username = context.Request.Form["username"],
                 Password = context.Request.Form["password"],
+                ClientId = context.Request.Form["client_id"],
+                ClientSecret = context.Request.Form["client_secret"],
                 Code = context.Request.Form["code"],
                 RedirectUri = context.Request.Form["redirect_uri"],
                 Scope = context.Request.Form["scope"]

--- a/src/Nancy.OAuth2/Models/TokenRequest.cs
+++ b/src/Nancy.OAuth2/Models/TokenRequest.cs
@@ -7,6 +7,8 @@ namespace Nancy.OAuth2.Models
         public string GrantType { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
         public string Code { get; set; }
         public string RedirectUri { get; set; }
         public IEnumerable<string> Scope { get; set; }

--- a/src/Nancy.OAuth2/OAuthConfiguration.cs
+++ b/src/Nancy.OAuth2/OAuthConfiguration.cs
@@ -34,7 +34,7 @@ namespace Nancy.OAuth2
 
             var value = member.GetValue(this, null);
 
-            return String.Concat(Base, "/", value);
+            return string.Concat(Base, "/", value);
         }
     }
 }


### PR DESCRIPTION
Need to be able to access the `ClientId` and `ClientSecret` when making a request to the token endpoint.